### PR TITLE
Double ID on raw query graph

### DIFF
--- a/backend/query_processor.go
+++ b/backend/query_processor.go
@@ -37,8 +37,12 @@ func (qp *QueryProcessor) processRawMetricQuery(query string, ds *CassandraDatas
 
 	frames := make([]*data.Frame, len(series))
 	i := 0
-	for _, serie := range series {
+	for id, serie := range series {
 		frame := timeSerieToFrame(serie)
+
+		frame.Fields[1].Config = &data.FieldConfig{
+			DisplayNameFromDS: id,
+		}
 
 		frames[i] = frame
 		i = i + 1


### PR DESCRIPTION
During testing I found a bug. When I make raw query request, IDs of data in legend is doubled