### PR TITLE
Enable alerting

### DIFF
--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -50,7 +50,6 @@ export class QueryEditor extends PureComponent<Props> {
 
   getKeyspaces(): Array<SelectableValue<string>> {
     const result: Array<SelectableValue<string>> = [];
-
     this.props.datasource.getKeyspaces().then((keyspaces: MetricFindValue[]) => {
       keyspaces.forEach((keyspace: MetricFindValue) => {
         result.push({ label: keyspace.text, value: keyspace.text });
@@ -154,6 +153,8 @@ export class QueryEditor extends PureComponent<Props> {
 
   render() {
     const options = this.props;
+
+    this.props.query.queryType = 'query';
 
     return (
       <div>

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -4,7 +4,7 @@
     "type": "datasource",
   
     "backend": true,
-    "alerting": false,
+    "alerting": true,
     "executable": "cassandra-plugin",
     "metrics": true,
     "annotations": false,


### PR DESCRIPTION
Enable alerting and properly set queryType for request (usually we set it after query editor, but alerting need it to be filled in query edit stage)
Also this feature need to be tested, because I'm not advanced grafana user
Fixes #91 