### PR TITLE
Added support of unixEpochFrom/unixEpochTo variables (#111)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Note that `PER PARTITION LIMIT 1` used instead of `LIMIT 1` to query one row for
 #### Unix epoch time format
 Usually there are no problems - Cassandra can store timestamps using different formats as shown in [documentation](https://cassandra.apache.org/doc/latest/cassandra/cql/types.html#timestamps).
 However, it is not always enough. One of possible cases could be unix time, which is just number of seconds or milliseconds and usually stored as integer type.
-1. If time is stored as number of milliseconds in a `bigint` column, then it should be converted into the `timestamp` type before return data to grafana:
+1. If time is stored as a number of milliseconds in a `bigint` column, then it should be converted into the `timestamp` type before return the data to grafana:
 ```
 SELECT sensor_id, temperature, dateOf(maxTimeuuid(registered_at)), location
 FROM test.test WHERE sensor_id = 99051fe9-6a9c-46c2-b949-38ef78858dd0
@@ -156,16 +156,15 @@ AND registered_at > $__timeFrom and registered_at < $__timeTo
 ```
 This query returns proper timestamp even if it stored as number of milliseconds.
 
-2. If time is stored as number of seconds, then it is not possible to convert it into the timestamp natively, but there is a trick:
+2. If time is stored as a number of seconds, then it is not possible to convert it into the timestamp natively, but there is a trick:
 ```
 SELECT sensor_id, temperature, dateOf(maxTimeuuid(registered_at*1000)), location
 FROM test.test WHERE sensor_id = 99051fe9-6a9c-46c2-b949-38ef78858dd0
 AND registered_at > $__unixEpochFrom and registered_at < $__unixEpochTo
 ```
 * There are two important parts in this query:
-  * `dateOf(maxTimeuuid(registered_at*1000))` used to convert seconds to milliseconds(`registered_at*1000`) and then convert milliseconds to `timestamp` type.
-  * `$__unixEpochFrom` and `$__unixEpochTo` are variables with unix time in seconds format which used to fill conditions part.
-
+  * `dateOf(maxTimeuuid(registered_at*1000))` used to convert seconds to milliseconds(`registered_at*1000`) and then to convert milliseconds to `timestamp` type, which is handed over to grafana.
+  * `$__unixEpochFrom` and `$__unixEpochTo` are variables with unix time in the seconds format that are used to fill out conditions part of the query.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,28 @@ PER PARTITION LIMIT 1
 ```
 Note that `PER PARTITION LIMIT 1` used instead of `LIMIT 1` to query one row for each partition and not just one row total.
 
+#### Unix epoch time format
+Usually there are no problems - Cassandra can store timestamps using different formats as shown in [documentation](https://cassandra.apache.org/doc/latest/cassandra/cql/types.html#timestamps).
+However, it is not always enough. One of possible cases could be unix time, which is just number of seconds or milliseconds and usually stored as integer type.
+1. If time is stored as number of milliseconds in a `bigint` column, then it should be converted into the `timestamp` type before return data to grafana:
+```
+SELECT sensor_id, temperature, dateOf(maxTimeuuid(registered_at)), location
+FROM test.test WHERE sensor_id = 99051fe9-6a9c-46c2-b949-38ef78858dd0
+AND registered_at > $__timeFrom and registered_at < $__timeTo
+```
+This query returns proper timestamp even if it stored as number of milliseconds.
+
+2. If time is stored as number of seconds, then it is not possible to convert it into the timestamp natively, but there is a trick:
+```
+SELECT sensor_id, temperature, dateOf(maxTimeuuid(registered_at*1000)), location
+FROM test.test WHERE sensor_id = 99051fe9-6a9c-46c2-b949-38ef78858dd0
+AND registered_at > $__unixEpochFrom and registered_at < $__unixEpochTo
+```
+* There are two important parts in this query:
+  * `dateOf(maxTimeuuid(registered_at*1000))` used to convert seconds to milliseconds(`registered_at*1000`) and then convert milliseconds to `timestamp` type.
+  * `$__unixEpochFrom` and `$__unixEpochTo` are variables with unix time in seconds format which used to fill conditions part.
+
+
 ## Development
 
 [Developer documentation](https://github.com/HadesArchitect/GrafanaCassandraDatasource/wiki/Developer-Guide)

--- a/backend/plugin/plugin_test.go
+++ b/backend/plugin/plugin_test.go
@@ -181,7 +181,7 @@ func TestPlugin_ExecQuery(t *testing.T) {
 			p := &Plugin{repo: tc.repo}
 			dataFrames, err := p.ExecQuery(context.TODO(), tc.query)
 			assert.NoError(t, err)
-			assert.Equal(t, tc.want, dataFrames)
+			assert.EqualValues(t, tc.want, dataFrames)
 		})
 	}
 }
@@ -395,7 +395,7 @@ func Test_makeDataFrameFromPoints(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			dataFrame := makeDataFrameFromPoints(tc.id, tc.alias, tc.rows)
-			assert.Equal(t, tc.want, dataFrame)
+			assert.EqualValues(t, tc.want, dataFrame)
 		})
 	}
 }

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -82,10 +82,12 @@ export class CassandraDatasource extends DataSourceWithBackend<CassandraQuery, C
   }
 
   buildQueryParameters(options: DataQueryRequest<CassandraQuery>): DataQueryRequest<CassandraQuery> {
-    let from = options.range.from.valueOf();
-    let to = options.range.to.valueOf();
-    options.scopedVars.__timeFrom = { text: from, value: from };
-    options.scopedVars.__timeTo = { text: to, value: to };
+    let from = options.range.from;
+    let to = options.range.to;
+    options.scopedVars.__timeFrom = { text: from.valueOf(), value: from.valueOf() };
+    options.scopedVars.__timeTo = { text: to.valueOf(), value: to.valueOf() };
+    options.scopedVars.__unixEpochFrom = { text: from.unix(), value: from.unix() };
+    options.scopedVars.__unixEpochTo = { text: to.unix(), value: to.unix() };
 
     //remove placeholder targets
     options.targets = _.filter(options.targets, (target) => {


### PR DESCRIPTION
* Added support of `$__unixEpochFrom` and `$__unixEpochTo` variables. They interpolate into number of **seconds** since 1970/01/01.
* Updated README.md to reflect this change and describe how to use it with non-timestamp columns.

Closes #111 