### PR TITLE
Unified alerting support

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Note that `PER PARTITION LIMIT 1` used instead of `LIMIT 1` to query one row for
 
 ### Alerting
 Alerting is supported, however it has some limitations. Grafana does not support long(narrow) series in alerting, 
-so query result must be converted to wide series before hading it over to grafana. Datasource performs it in pretty
+so query result must be converted to wide series before handing it over to grafana. Datasource performs it in pretty
 simple way - it creates labels using all the non-timeseries field and then removes that fields from response.
 Basically, this query(using example table)
 ```
@@ -209,6 +209,41 @@ AND registered_at > $__unixEpochFrom AND registered_at < $__unixEpochTo
 * There are two important parts in this query:
   * `dateOf(maxTimeuuid(registered_at*1000))` used to convert seconds to milliseconds(`registered_at*1000`) and then to convert milliseconds to `timestamp` type, which is handed over to grafana.
   * `$__unixEpochFrom` and `$__unixEpochTo` are variables with unix time in the seconds format that are used to fill out conditions part of the query.
+
+#### Cassandra fat partitions
+Cassandra stores data in `partitions` which are minimal storage units for the DB. It means that using the example table
+```
+CREATE TABLE IF NOT EXISTS temperature (
+    sensor_id uuid,
+    registered_at timestamp,
+    temperature int,
+    PRIMARY KEY ((sensor_id), registered_at)
+);
+```
+will lead to partitions bloating and performance degradation, because all the data for all time for specific `sensor_id` is stored in just one partition(first part of `PRIMARY KEY` is `PARTITION KEY`).
+To avoid that there is a technique called `bucketing`, which basically means that partitions are split up into smaller pieces.
+For instance, we can split that example table partitions by time: year, month, day, or even hour and less. What to choose depends on how
+much data stored in each partition. To achieve that the example table has to be modified like this:
+```
+CREATE TABLE IF NOT EXISTS temperature (
+    sensor_id uuid,
+    date date,
+    registered_at timestamp,
+    temperature int,
+    PRIMARY KEY ((sensor_id, date), registered_at)
+);
+```
+After that change the database schema became more effective because of bucketing by date, and queries will have a form of
+```
+SELECT sensor_id, temperature, registered_at
+FROM temperature
+WHERE sensor_id IN (99051fe9-6a9c-46c2-b949-38ef78858dd1, 99051fe9-6a9c-46c2-b949-38ef78858dd0) 
+AND date = '${__from:date:YYYY-MM-DD}'
+AND registered_at > $__timeFrom 
+AND registered_at < $__timeTo
+```
+Note that `$__from`/`$__to` variables are used. They are [grafana built-in variables](https://grafana.com/docs/grafana/latest/dashboards/variables/add-template-variables/#__from-and-__to), and they have formatting capabilities which are perfect for our case.
+In case when time range includes more than one day, each day has to be added into `AND date IN (...)` predicate. Another way to make it more convenient is to consider using larger buckets, e.g. month instead of day-size.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -139,8 +139,7 @@ After that the most recent value will always be stored in the beginning of parti
 SELECT sensor_id, temperature, registered_at, room_name
 FROM test.test
 WHERE sensor_id IN (99051fe9-6a9c-46c2-b949-38ef78858dd0, 99051fe9-6a9c-46c2-b949-38ef78858dd0)
-AND registered_at > $__timeFrom and registered_at < $__timeTo
-ORDER BY registered_at
+AND registered_at > $__timeFrom AND registered_at < $__timeTo
 PER PARTITION LIMIT 1
 ```
 Note that `PER PARTITION LIMIT 1` used instead of `LIMIT 1` to query one row for each partition and not just one row total.
@@ -152,7 +151,7 @@ However, it is not always enough. One of possible cases could be unix time, whic
 ```
 SELECT sensor_id, temperature, dateOf(maxTimeuuid(registered_at)), location
 FROM test.test WHERE sensor_id = 99051fe9-6a9c-46c2-b949-38ef78858dd0
-AND registered_at > $__timeFrom and registered_at < $__timeTo
+AND registered_at > $__timeFrom AND registered_at < $__timeTo
 ```
 This query returns proper timestamp even if it stored as number of milliseconds.
 
@@ -160,7 +159,7 @@ This query returns proper timestamp even if it stored as number of milliseconds.
 ```
 SELECT sensor_id, temperature, dateOf(maxTimeuuid(registered_at*1000)), location
 FROM test.test WHERE sensor_id = 99051fe9-6a9c-46c2-b949-38ef78858dd0
-AND registered_at > $__unixEpochFrom and registered_at < $__unixEpochTo
+AND registered_at > $__unixEpochFrom AND registered_at < $__unixEpochTo
 ```
 * There are two important parts in this query:
   * `dateOf(maxTimeuuid(registered_at*1000))` used to convert seconds to milliseconds(`registered_at*1000`) and then to convert milliseconds to `timestamp` type, which is handed over to grafana.

--- a/backend/cassandra/row.go
+++ b/backend/cassandra/row.go
@@ -23,6 +23,9 @@ func (r *Row) normalize() error {
 	for _, colName := range r.Columns {
 		switch v := r.Fields[colName].(type) {
 		case int8, int16, int32, int64, float32, float64, string, bool, time.Time:
+		// nulls are not supported yet, so just in case they will`
+		// https://github.com/gocql/gocql/issues/1248
+		case *int, *int8, *int16, *int32, *int64, *float32, *float64, *string, *bool:
 		case int:
 			r.Fields[colName] = int64(v)
 		case []byte:

--- a/backend/handler/data_query_test.go
+++ b/backend/handler/data_query_test.go
@@ -61,6 +61,29 @@ func Test_parseDataQuery(t *testing.T) {
 				Instant:        false,
 			},
 		},
+		{
+			name:      "alert query",
+			timeRange: backend.TimeRange{From: time.Unix(1257894000, 0), To: time.Unix(1257894010, 0)},
+			jsonStr: []byte(`{"datasourceId": 1, "queryType": "alert", "rawQuery": true, "refId": "123456789",
+					   		  "target": "SELECT * from Keyspace.Table", "columnTime": "Time", "columnValue": "Value",
+					   		  "keyspace": "Keyspace", "table": "Table", "columnId": "ID", "valueId": "123"}`),
+			want: &plugin.Query{
+				RawQuery:       true,
+				Target:         "SELECT * from Keyspace.Table",
+				Keyspace:       "Keyspace",
+				Table:          "Table",
+				ColumnValue:    "Value",
+				ColumnID:       "ID",
+				ValueID:        "123",
+				AliasID:        "",
+				ColumnTime:     "Time",
+				TimeFrom:       time.Unix(1257894000, 0),
+				TimeTo:         time.Unix(1257894010, 0),
+				AllowFiltering: false,
+				Instant:        false,
+				IsAlertQuery:   true,
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/backend/handler/handler.go
+++ b/backend/handler/handler.go
@@ -41,6 +41,7 @@ func New(fn datasource.InstanceFactoryFunc) datasource.ServeOpts {
 	// QueryDataHandler
 	queryTypeMux := datasource.NewQueryTypeMux()
 	queryTypeMux.HandleFunc("query", h.queryMetricData)
+	queryTypeMux.HandleFunc("alert", h.queryMetricData)
 
 	return datasource.ServeOpts{
 		CheckHealthHandler:  h,
@@ -59,6 +60,7 @@ func (h *handler) queryMetricData(ctx context.Context, req *backend.QueryDataReq
 
 	responses := backend.Responses{}
 	for _, q := range req.Queries {
+		backend.Logger.Debug("Process metrics request", "Request", q.JSON)
 		cassQuery, err := parseDataQuery(&q)
 		if err != nil {
 			backend.Logger.Error("Failed to parse query", "Message", err)

--- a/backend/plugin/query.go
+++ b/backend/plugin/query.go
@@ -21,17 +21,17 @@ type Query struct {
 	TimeTo         time.Time
 	AllowFiltering bool
 	Instant        bool
+	IsAlertQuery   bool
 }
 
 // BuildStatement builds cassandra query statement with positional parameters.
 func (q *Query) BuildStatement() string {
-	var (
-		allowFiltering    string
-		perPartitionLimit string
-	)
+	var allowFiltering string
 	if q.AllowFiltering {
 		allowFiltering = " ALLOW FILTERING"
 	}
+
+	var perPartitionLimit string
 	if q.Instant {
 		perPartitionLimit = " PER PARTITION LIMIT 1"
 	}

--- a/src/ConfigEditor.tsx
+++ b/src/ConfigEditor.tsx
@@ -15,7 +15,6 @@ export class ConfigEditor extends PureComponent<Props, State> {
       event.target.setCustomValidity('Cannot be empty');
       event.target.placeholder = 'This field cannot be empty!';
       event.target.style.setProperty('border-color', 'red');
-      console.log(event.target.form);
     } else {
       event.target.setCustomValidity('');
       event.target.placeholder = 'cassandra:9042';

--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -150,6 +150,9 @@ export class QueryEditor extends PureComponent<Props> {
     const options = this.props;
 
     this.props.query.queryType = 'query';
+    if (this.props.app === 'unified-alerting') {
+      this.props.query.queryType = 'alert';
+    }
 
     return (
       <div>
@@ -159,7 +162,7 @@ export class QueryEditor extends PureComponent<Props> {
               <InlineField
                 label="Cassandra CQL Query"
                 labelWidth={30}
-                tooltip="Enter Cassandra CQL query. Also you can use $__timeFrom and $__timeTo variables, it will be replaced by chosen range"
+                tooltip="Enter Cassandra CQL query. You can use $__timeFrom/$__timeTo and $__unixEpochFrom/$__unixEpochTo variables, they will be replaced by chosen range"
                 grow
               >
                 <TextArea
@@ -175,9 +178,9 @@ export class QueryEditor extends PureComponent<Props> {
               <InlineField label="Alias" labelWidth={30} tooltip="Series name override. Plain text or template using column names, e.g. `{{ column1 }}:{{ column2}}`">
                 <Input
                     name="alias"
-                    value={this.props.query.alias || ''}
                     onChange={this.onAliasChange}
                     onBlur={this.props.onRunQuery}
+                    value={this.props.query.alias || ''}
                 />
               </InlineField>
             </InlineFieldRow>
@@ -294,7 +297,7 @@ export class QueryEditor extends PureComponent<Props> {
               <InlineField
                 label="ID Column"
                 labelWidth={30}
-                tooltip="Specify name of a UUID column to identify the row (id, sensor_id etc.)"
+                tooltip="Specify name of a ID column to identify the row (id, sensor_id etc.)"
               >
                 {/* <Input
                   name="id_column"

--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -1,8 +1,8 @@
-import React, { ChangeEvent, PureComponent, FormEvent } from 'react';
-import { Button, InlineField, InlineFieldRow, Input, InlineSwitch, Select, TextArea } from '@grafana/ui';
-import { QueryEditorProps, SelectableValue } from '@grafana/data';
-import { CassandraDatasource, CassandraDataSourceOptions } from './datasource';
-import { CassandraQuery } from './models';
+import React, {ChangeEvent, FormEvent, PureComponent} from 'react';
+import {Button, InlineField, InlineFieldRow, InlineSwitch, Input, Select, TextArea} from '@grafana/ui';
+import {CoreApp, QueryEditorProps, SelectableValue} from '@grafana/data';
+import {CassandraDatasource, CassandraDataSourceOptions} from './datasource';
+import {CassandraQuery} from './models';
 
 type Props = QueryEditorProps<CassandraDatasource, CassandraQuery, CassandraDataSourceOptions>;
 
@@ -150,7 +150,7 @@ export class QueryEditor extends PureComponent<Props> {
     const options = this.props;
 
     this.props.query.queryType = 'query';
-    if (this.props.app === 'unified-alerting') {
+    if (this.props.app !== undefined && this.props.app === CoreApp.UnifiedAlerting) {
       this.props.query.queryType = 'alert';
     }
 
@@ -162,7 +162,7 @@ export class QueryEditor extends PureComponent<Props> {
               <InlineField
                 label="Cassandra CQL Query"
                 labelWidth={30}
-                tooltip="Enter Cassandra CQL query. You can use $__timeFrom/$__timeTo and $__unixEpochFrom/$__unixEpochTo variables, they will be replaced by chosen range"
+                tooltip="Enter Cassandra CQL query. There are $__timeFrom/$__timeTo, $__unixEpochFrom/$__unixEpochTo and $__from/$__to variables to dynamically limit time range in queries. You should always use them to avoid excessive data fetching from DB."
                 grow
               >
                 <TextArea

--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -28,7 +28,15 @@ export class QueryEditor extends PureComponent<Props> {
         children?: React.ReactNode;
       }>
   ) {
-    if (
+    this.props.query.queryType = 'query';
+    if (this.props.app && this.props.app === CoreApp.UnifiedAlerting) {
+      this.props.query.queryType = 'alert';
+    }
+
+    const { onChange, query } = this.props;
+    onChange({ ...query, queryType: props.query.queryType });
+
+    if ((
       props.query.keyspace &&
       props.query.keyspace !== '' &&
       props.query.table &&
@@ -41,7 +49,8 @@ export class QueryEditor extends PureComponent<Props> {
       props.query.columnId !== '' &&
       props.query.valueId &&
       props.query.valueId !== ''
-    ) {
+      ) || (props.query.target && props.query.target !== ''))
+    {
       this.props.onRunQuery();
     }
   }
@@ -149,11 +158,6 @@ export class QueryEditor extends PureComponent<Props> {
   render() {
     const options = this.props;
 
-    this.props.query.queryType = 'query';
-    if (this.props.app !== undefined && this.props.app === CoreApp.UnifiedAlerting) {
-      this.props.query.queryType = 'alert';
-    }
-
     return (
       <div>
         {options.query.rawQuery && (
@@ -168,7 +172,9 @@ export class QueryEditor extends PureComponent<Props> {
                 <TextArea
                   placeholder={'Enter a CQL query'}
                   onChange={this.onQueryTextChange}
-                  onBlur={this.props.onRunQuery}
+                  onBlur={() => {
+                    this.onRunQuery(this.props);
+                  }}
                   value={this.props.query.target}
                 />
               </InlineField>
@@ -179,7 +185,9 @@ export class QueryEditor extends PureComponent<Props> {
                 <Input
                     name="alias"
                     onChange={this.onAliasChange}
-                    onBlur={this.props.onRunQuery}
+                    onBlur={() => {
+                      this.onRunQuery(this.props);
+                    }}
                     value={this.props.query.alias || ''}
                 />
               </InlineField>

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -82,13 +82,6 @@ export class CassandraDatasource extends DataSourceWithBackend<CassandraQuery, C
   }
 
   buildQueryParameters(options: DataQueryRequest<CassandraQuery>): DataQueryRequest<CassandraQuery> {
-    let from = options.range.from;
-    let to = options.range.to;
-    options.scopedVars.__timeFrom = { text: from.valueOf(), value: from.valueOf() };
-    options.scopedVars.__timeTo = { text: to.valueOf(), value: to.valueOf() };
-    options.scopedVars.__unixEpochFrom = { text: from.unix(), value: from.unix() };
-    options.scopedVars.__unixEpochTo = { text: to.unix(), value: to.unix() };
-
     //remove placeholder targets
     options.targets = _.filter(options.targets, (target) => {
       return target.target !== 'select metric';
@@ -97,7 +90,7 @@ export class CassandraDatasource extends DataSourceWithBackend<CassandraQuery, C
     const targets: CassandraQuery[] = _.map(options.targets, (target) => {
       return {
         datasourceId: target.datasourceId,
-        queryType: 'query',
+        queryType: target.queryType,
 
         target: getTemplateSrv().replace(target.target, options.scopedVars, 'csv'),
         refId: target.refId,

--- a/src/models.ts
+++ b/src/models.ts
@@ -16,4 +16,4 @@ export interface CassandraQuery extends DataQuery {
   instant?: boolean;
 }
 
-type CassandraQueryType = 'query' | 'search' | 'keyspaces' | 'tables';
+type CassandraQueryType = 'query' | 'alert';


### PR DESCRIPTION
* Supported unified alerting including time range variables interpolation for alerting queries. To achieve that:
  * new `alert` handler was added(just to distinguish usual query and alert query contexts)
  * frame transformation from long to wide format was added - basically, moving of non-TS(non numeric and non timestamp)  fields to labels, because grafana alerting doesn't support long series. https://grafana.com/developers/plugin-tools/introduction/data-frames#data-frames-as-time-series 
* Moved range variable interpolation to backend to avoid logic duplication
* Minor fixes and typo corrections
* README.md updated

Fixes #158 