### PR TITLE
add "" to  GF_AUTH_ANONYMOUS_ENABLED: "true"       GF_AUTH_BASIC_ENABLED: "false"

### DIFF
--- a/demo/docker-compose.yaml
+++ b/demo/docker-compose.yaml
@@ -7,8 +7,8 @@ services:
     environment:
       GF_LOG_LEVEL: debug
       GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
-      GF_AUTH_ANONYMOUS_ENABLED: true
-      GF_AUTH_BASIC_ENABLED: false
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_BASIC_ENABLED: "false"
       GF_DEFAULT_APP_MODE: development
     volumes:
       - ./grafana.db:/var/lib/grafana/grafana.db

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,8 +7,8 @@ services:
     environment:
       GF_LOG_LEVEL: debug
       GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
-      GF_AUTH_ANONYMOUS_ENABLED: true
-      GF_AUTH_BASIC_ENABLED: false
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_BASIC_ENABLED: "false"
       GF_DEFAULT_APP_MODE: development
       #GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: hadesarchitect-cassandra-datasource
     volumes:


### PR DESCRIPTION
i have error with default docker-compose.yaml : docker-compose up -d
ERROR: The Compose file './docker-compose.yaml' is invalid because:
services.grafana.environment.GF_AUTH_ANONYMOUS_ENABLED contains true, which is an invalid type, it should be a string, number, or a null
