### PR TITLE
feat: implement caching for tables and columns

### DIFF
--- a/.changeset/chatty-terms-prove.md
+++ b/.changeset/chatty-terms-prove.md
@@ -1,0 +1,5 @@
+---
+'grafana-cassandra-datasource': minor
+---
+
+Added keyspace, table, column caching for faster dropdown loading (@HadesArchitect)

--- a/.changeset/chatty-terms-prove1.md
+++ b/.changeset/chatty-terms-prove1.md
@@ -1,0 +1,5 @@
+---
+'grafana-cassandra-datasource': patch
+---
+
+Fixed #198 (@HadesArchitect)


### PR DESCRIPTION
- Adds caching for tables (per keyspace) and columns (per keyspace+table+type).
- Updates QueryEditor to use state management for all dropdown options.
- Fixes #198
