### PR TITLE
chore: use yarn instead of npm in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
       plugin-id: ${{ steps.metadata.outputs.plugin-id }}
       plugin-version: ${{ steps.metadata.outputs.plugin-version }}
       has-e2e: ${{ steps.check-for-e2e.outputs.has-e2e }}
-      has-backend: ${{ steps.check-for-backend.outputs.has-backend }}
     env:
       GRAFANA_ACCESS_POLICY_TOKEN: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
     steps:
@@ -36,36 +35,28 @@ jobs:
 
       - name: Check types
         run: yarn typecheck
+
       - name: Lint
         run: yarn lint
+
       - name: Unit tests
         run: yarn test:ci
+
       - name: Build frontend
         run: yarn build
 
-      - name: Check for backend
-        id: check-for-backend
-        run: |
-          if [ -f "Magefile.go" ]
-          then
-            echo "has-backend=true" >> $GITHUB_OUTPUT
-          fi
-
       - name: Setup Go environment
-        if: steps.check-for-backend.outputs.has-backend == 'true'
         uses: actions/setup-go@v5
         with:
           go-version: '1.22'
 
       - name: Test backend
-        if: steps.check-for-backend.outputs.has-backend == 'true'
         uses: magefile/mage-action@6f50bbb8ea47d56e62dee92392788acbc8192d0b # v3.1.0
         with:
           version: latest
           args: coverage
 
       - name: Build backend
-        if: steps.check-for-backend.outputs.has-backend == 'true'
         uses: magefile/mage-action@6f50bbb8ea47d56e62dee92392788acbc8192d0b # v3.1.0
         with:
           version: latest
@@ -165,7 +156,6 @@ jobs:
           name: ${{ needs.build.outputs.plugin-id }}-${{ needs.build.outputs.plugin-version }}
 
       - name: Execute permissions on binary
-        if: needs.build.outputs.has-backend == 'true'
         run: |
           chmod +x ./dist/gpx_*
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,19 +29,19 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
-          cache: 'npm'
+          cache: 'yarn'
 
       - name: Install dependencies
-        run: npm ci
+        run: yarn install --immutable
 
       - name: Check types
-        run: npm run typecheck
+        run: yarn typecheck
       - name: Lint
-        run: npm run lint
+        run: yarn lint
       - name: Unit tests
-        run: npm run test:ci
+        run: yarn test:ci
       - name: Build frontend
-        run: npm run build
+        run: yarn build
 
       - name: Check for backend
         id: check-for-backend
@@ -80,7 +80,7 @@ jobs:
           fi
 
       - name: Sign plugin
-        run: npm run sign
+        run: yarn sign
         if: ${{ env.GRAFANA_ACCESS_POLICY_TOKEN != '' }}
 
       - name: Get plugin metadata
@@ -173,10 +173,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
-          cache: 'npm'
+          cache: 'yarn'
 
       - name: Install dev dependencies
-        run: npm ci
+        run: yarn install --immutable
 
       - name: Start Grafana
         run: |
@@ -189,11 +189,11 @@ jobs:
           url: http://localhost:3000/login
 
       - name: Install Playwright Browsers
-        run: npm exec playwright install chromium --with-deps
+        run: yarn playwright install chromium --with-deps
 
       - name: Run Playwright tests
         id: run-tests
-        run: npm run e2e
+        run: yarn e2e
 
       - name: Upload e2e test summary
         uses: grafana/plugin-actions/playwright-gh-pages/upload-report-artifacts@main # zizmor: ignore[unpinned-uses] provided by grafana

--- a/.github/workflows/is-compatible.yml
+++ b/.github/workflows/is-compatible.yml
@@ -15,13 +15,13 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
-          cache: 'npm'
+          cache: 'yarn'
 
       - name: Install dependencies
-        run: npm ci
+        run: yarn install --frozen-lockfile
 
       - name: Build plugin
-        run: npm run build
+        run: yarn build
 
       - name: Find module.ts or module.tsx
         id: find-module-ts

--- a/.github/workflows/is-compatible.yml
+++ b/.github/workflows/is-compatible.yml
@@ -18,7 +18,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --immutable
 
       - name: Build plugin
         run: yarn build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,31 @@ on:
 permissions: read-all
 
 jobs:
+  test:
+    name: Build, lint and unit tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'yarn'
+      - name: Install dependencies
+        run: yarn install --immutable
+      - name: Check types
+        run: yarn typecheck
+      - name: Lint
+        run: yarn lint
+      - name: Unit tests
+        run: yarn test:ci
+
   release:
+    needs: test
     permissions:
       contents: write
       id-token: write

--- a/src/__tests__/QueryEditor.test.tsx
+++ b/src/__tests__/QueryEditor.test.tsx
@@ -119,15 +119,15 @@ describe('QueryEditor', () => {
     expect(mockDatasource.getKeyspaces).toHaveBeenCalledTimes(1);
   });
 
-  it('should toggle query type when button is clicked', async () => {
+  it('should toggle query type when radio button is clicked', async () => {
     const mockOnChange = jest.fn();
     const propsWithMockOnChange = { ...mockProps, onChange: mockOnChange };
 
     await renderComponent({ ...propsWithMockOnChange });
 
-    // Find and click the toggle button
-    const toggleButton = screen.getByRole('button', { name: /toggle editor mode/i });
-    fireEvent.click(toggleButton);
+    // Find and click the "Query Editor" radio option to switch to raw query mode
+    const queryEditorRadio = screen.getByRole('radio', { name: /query editor/i });
+    fireEvent.click(queryEditorRadio);
 
     // Verify onChange was called with toggled rawQuery
     expect(mockOnChange).toHaveBeenCalledWith({ ...mockQuery, rawQuery: !mockQuery.rawQuery });


### PR DESCRIPTION
Switches the CI workflow from npm to yarn:

- Replace `npm ci` with `yarn install --immutable`
- Replace `npm run <script>` with `yarn <script>`
- Replace `npm exec playwright` with `yarn playwright`
- Update node cache from `npm` to `yarn`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI and compatibility workflows switched to Yarn for caching, install, build, lint, typecheck, test, signing, and Playwright e2e steps.
  * Backend presence gating removed and frontend build reordered before backend setup; artifact and test upload steps aligned with Yarn.
* **Chores**
  * Release workflow now requires a pre-release test job that runs build, lint, typecheck, and unit tests.
* **Tests**
  * Unit test updated to toggle mode via a radio input to verify change handlers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->