### PR TITLE
Added the ability to configure AllowedAuthenticators of gocql driver

### DIFF
--- a/.changeset/tired-tools-wave.md
+++ b/.changeset/tired-tools-wave.md
@@ -2,4 +2,8 @@
 'grafana-cassandra-datasource': minor
 ---
 
-Added the ability to configure AllowedAuthenticators from frontend to support querying clusters with "custom" authenticators. Frontend string is a semicolon separted array which is split by the backend and passed on to gocql driver.
+Added support for Cassandra clusters that use non-standard authenticators (e.g. LDAP).
+
+Previously, connecting to such clusters would fail during the initial handshake with an `unexpected authenticator` error.
+
+A new **Allowed authenticators** field in the connection settings lets you specify which authenticator class names the driver should accept, as a semicolon-separated list. Leaving it empty preserves the original behaviour, so existing data sources are unaffected.

--- a/.changeset/tired-tools-wave.md
+++ b/.changeset/tired-tools-wave.md
@@ -1,0 +1,5 @@
+---
+'grafana-cassandra-datasource': minor
+---
+
+Added the ability to configure AllowedAuthenticators from frontend to support querying clusters with "custom" authenticators. Frontend string is a semicolon separted array which is split by the backend and passed on to gocql driver.

--- a/.changeset/tired-tools-wave.md
+++ b/.changeset/tired-tools-wave.md
@@ -2,8 +2,6 @@
 'grafana-cassandra-datasource': minor
 ---
 
-Added support for Cassandra clusters that use non-standard authenticators (e.g. LDAP).
-
-Previously, connecting to such clusters would fail during the initial handshake with an `unexpected authenticator` error.
+Added support for Cassandra clusters that use non-standard authenticators (e.g. LDAP). Previously, connecting to such clusters would fail during the initial handshake with an `unexpected authenticator` error.
 
 A new **Allowed authenticators** field in the connection settings lets you specify which authenticator class names the driver should accept, as a semicolon-separated list. Leaving it empty preserves the original behaviour, so existing data sources are unaffected.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,119 +111,121 @@ jobs:
           path: ${{ steps.metadata.outputs.plugin-id }}
           retention-days: 5
 
-  resolve-versions:
-    name: Resolve e2e images
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    timeout-minutes: 3
-    needs: build
-    if: ${{ needs.build.outputs.has-e2e == 'true' }}
-    outputs:
-      matrix: ${{ steps.resolve-versions.outputs.matrix }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
+  # E2E jobs below are scaffolded but not yet active (no playwright.config.ts).
+  # Uncomment when Playwright tests are added.
 
-      - name: Resolve Grafana E2E versions
-        id: resolve-versions
-        uses: grafana/plugin-actions/e2e-version@main # zizmor: ignore[unpinned-uses] provided by grafana
+  # resolve-versions:
+  #   name: Resolve e2e images
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     contents: read
+  #   timeout-minutes: 3
+  #   needs: build
+  #   if: ${{ needs.build.outputs.has-e2e == 'true' }}
+  #   outputs:
+  #     matrix: ${{ steps.resolve-versions.outputs.matrix }}
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #       with:
+  #         persist-credentials: false
+  #
+  #     - name: Resolve Grafana E2E versions
+  #       id: resolve-versions
+  #       uses: grafana/plugin-actions/e2e-version@main # zizmor: ignore[unpinned-uses] provided by grafana
 
-  playwright-tests:
-    needs: [resolve-versions, build]
-    timeout-minutes: 15
-    permissions:
-      contents: read
-      id-token: write
-      pull-requests: write
-    strategy:
-      fail-fast: false
-      matrix:
-        GRAFANA_IMAGE: ${{fromJson(needs.resolve-versions.outputs.matrix)}}
-    name: e2e test ${{ matrix.GRAFANA_IMAGE.name }}@${{ matrix.GRAFANA_IMAGE.VERSION }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
+  # playwright-tests:
+  #   needs: [resolve-versions, build]
+  #   timeout-minutes: 15
+  #   permissions:
+  #     contents: read
+  #     id-token: write
+  #     pull-requests: write
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       GRAFANA_IMAGE: ${{fromJson(needs.resolve-versions.outputs.matrix)}}
+  #   name: e2e test ${{ matrix.GRAFANA_IMAGE.name }}@${{ matrix.GRAFANA_IMAGE.VERSION }}
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         persist-credentials: false
+  #
+  #     - name: Download plugin
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         path: dist
+  #         name: ${{ needs.build.outputs.plugin-id }}-${{ needs.build.outputs.plugin-version }}
+  #
+  #     - name: Execute permissions on binary
+  #       run: |
+  #         chmod +x ./dist/gpx_*
+  #
+  #     - name: Setup Node.js environment
+  #       uses: actions/setup-node@v4
+  #       with:
+  #         node-version: '22'
+  #         cache: 'yarn'
+  #
+  #     - name: Install dev dependencies
+  #       run: yarn install --immutable
+  #
+  #     - name: Start Grafana
+  #       run: |
+  #         docker compose pull
+  #         ANONYMOUS_AUTH_ENABLED=false DEVELOPMENT=false GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} docker compose up -d
+  #
+  #     - name: Wait for grafana server
+  #       uses: grafana/plugin-actions/wait-for-grafana@main # zizmor: ignore[unpinned-uses] provided by grafana
+  #       with:
+  #         url: http://localhost:3000/login
+  #
+  #     - name: Install Playwright Browsers
+  #       run: yarn playwright install chromium --with-deps
+  #
+  #     - name: Run Playwright tests
+  #       id: run-tests
+  #       run: yarn e2e
+  #
+  #     - name: Upload e2e test summary
+  #       uses: grafana/plugin-actions/playwright-gh-pages/upload-report-artifacts@main # zizmor: ignore[unpinned-uses] provided by grafana
+  #       if: ${{ always() && !cancelled() }}
+  #       with:
+  #         upload-report: false
+  #         github-token: ${{ secrets.GITHUB_TOKEN }}
+  #         test-outcome: ${{ steps.run-tests.outcome }}
+  #
+  #     - name: Docker logs
+  #       if: ${{ always() && steps.run-tests.outcome == 'failure' }}
+  #       run: |
+  #         docker logs hadesarchitect-gcds-datasource >& grafana-server.log
+  #
+  #     - name: Stop grafana docker
+  #       run: docker compose down
+  #
+  #     # - name: Upload server log
+  #     #   uses: actions/upload-artifact@v4
+  #     #   if: ${{ always() && steps.run-tests.outcome == 'failure' }}
+  #     #   with:
+  #     #     name: ${{ matrix.GRAFANA_IMAGE.NAME }}-v${{ matrix.GRAFANA_IMAGE.VERSION }}-${{github.run_id}}-server-log
+  #     #     path: grafana-server.log
+  #     #     retention-days: 5
 
-      - name: Download plugin
-        uses: actions/download-artifact@v4
-        with:
-          path: dist
-          name: ${{ needs.build.outputs.plugin-id }}-${{ needs.build.outputs.plugin-version }}
-
-      - name: Execute permissions on binary
-        run: |
-          chmod +x ./dist/gpx_*
-
-      - name: Setup Node.js environment
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'yarn'
-
-      - name: Install dev dependencies
-        run: yarn install --immutable
-
-      - name: Start Grafana
-        run: |
-          docker compose pull
-          ANONYMOUS_AUTH_ENABLED=false DEVELOPMENT=false GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} docker compose up -d
-
-      - name: Wait for grafana server
-        uses: grafana/plugin-actions/wait-for-grafana@main # zizmor: ignore[unpinned-uses] provided by grafana
-        with:
-          url: http://localhost:3000/login
-
-      - name: Install Playwright Browsers
-        run: yarn playwright install chromium --with-deps
-
-      - name: Run Playwright tests
-        id: run-tests
-        run: yarn e2e
-
-      - name: Upload e2e test summary
-        uses: grafana/plugin-actions/playwright-gh-pages/upload-report-artifacts@main # zizmor: ignore[unpinned-uses] provided by grafana
-        if: ${{ always() && !cancelled() }}
-        with:
-          upload-report: false
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          test-outcome: ${{ steps.run-tests.outcome }}
-
-      - name: Docker logs
-        if: ${{ always() && steps.run-tests.outcome == 'failure' }}
-        run: |
-          docker logs hadesarchitect-gcds-datasource >& grafana-server.log
-
-      - name: Stop grafana docker
-        run: docker compose down
-
-      # Uncomment this step to upload the server log to Github artifacts. Remember Github artifacts are public on the Internet if the repository is public.
-      # - name: Upload server log
-      #   uses: actions/upload-artifact@v4
-      #   if: ${{ always() && steps.run-tests.outcome == 'failure' }}
-      #   with:
-      #     name: ${{ matrix.GRAFANA_IMAGE.NAME }}-v${{ matrix.GRAFANA_IMAGE.VERSION }}-${{github.run_id}}-server-log
-      #     path: grafana-server.log
-      #     retention-days: 5
-
-  publish-report:
-    if: ${{ always() && !cancelled() }}
-    permissions:
-      contents: write
-      id-token: write
-      pull-requests: write
-    needs: [playwright-tests]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          # required for playwright-gh-pages
-          persist-credentials: true
-      - name: Publish report
-        uses: grafana/plugin-actions/playwright-gh-pages/deploy-report-pages@main # zizmor: ignore[unpinned-uses] provided by grafana
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+  # publish-report:
+  #   if: ${{ always() && !cancelled() }}
+  #   permissions:
+  #     contents: write
+  #     id-token: write
+  #     pull-requests: write
+  #   needs: [playwright-tests]
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         # required for playwright-gh-pages
+  #         persist-credentials: true
+  #     - name: Publish report
+  #       uses: grafana/plugin-actions/playwright-gh-pages/deploy-report-pages@main # zizmor: ignore[unpinned-uses] provided by grafana
+  #       with:
+  #         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.kilocode/package-lock.json
+++ b/.kilocode/package-lock.json
@@ -1,0 +1,380 @@
+{
+  "name": ".kilocode",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@kilocode/plugin": "7.3.54"
+      }
+    },
+    "node_modules/@kilocode/plugin": {
+      "version": "7.3.54",
+      "resolved": "https://registry.npmjs.org/@kilocode/plugin/-/plugin-7.3.54.tgz",
+      "integrity": "sha512-vwUXi6cSgGKCMFThPySZo8io9cz2EmoBN/6mOBYxkDj0zJxqGlEwq4iO012nwuHwdsGtAmo5OOoOfheHGnr2pA==",
+      "license": "MIT",
+      "dependencies": {
+        "@kilocode/sdk": "7.3.54",
+        "effect": "4.0.0-beta.66",
+        "zod": "4.1.8"
+      },
+      "peerDependencies": {
+        "@opentui/core": ">=0.2.15",
+        "@opentui/keymap": ">=0.2.15",
+        "@opentui/solid": ">=0.2.15"
+      },
+      "peerDependenciesMeta": {
+        "@opentui/core": {
+          "optional": true
+        },
+        "@opentui/keymap": {
+          "optional": true
+        },
+        "@opentui/solid": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@kilocode/sdk": {
+      "version": "7.3.54",
+      "resolved": "https://registry.npmjs.org/@kilocode/sdk/-/sdk-7.3.54.tgz",
+      "integrity": "sha512-A+g744DVuAHXSU3pu6BLe2AoxEh4fq7NdrYvlET3+waXSS0tG41Blr3ItCKSMLJH5M6C4rK2ZXi7plzkPNbdmA==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "7.0.6"
+      }
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.4.tgz",
+      "integrity": "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.4.tgz",
+      "integrity": "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.4.tgz",
+      "integrity": "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.4.tgz",
+      "integrity": "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.4.tgz",
+      "integrity": "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.4.tgz",
+      "integrity": "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/effect": {
+      "version": "4.0.0-beta.66",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.66.tgz",
+      "integrity": "sha512-4arEr62cziFa8BBVDUwJCJJmaVepXf/kRg7KtC0h8+bufngscrHbwWFhr9c+HonwOF+31U3iD3xUJmw9KzX7Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "fast-check": "^4.6.0",
+        "find-my-way-ts": "^0.1.6",
+        "ini": "^6.0.0",
+        "kubernetes-types": "^1.30.0",
+        "msgpackr": "^1.11.9",
+        "multipasta": "^0.2.7",
+        "toml": "^4.1.1",
+        "uuid": "^13.0.0",
+        "yaml": "^2.8.3"
+      }
+    },
+    "node_modules/fast-check": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.8.0.tgz",
+      "integrity": "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
+    "node_modules/find-my-way-ts": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz",
+      "integrity": "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==",
+      "license": "MIT"
+    },
+    "node_modules/ini": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/kubernetes-types": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
+      "integrity": "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/msgpackr": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.12.1.tgz",
+      "integrity": "sha512-4EUH9tQHnMmEgzW/MdAP0KIfa1T9AF+htl0ffe2n5vb2EKn9y2co8ccpgWko6S52Jy1PQZKwRnx5/KkYjtd9MQ==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.2"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.4.tgz",
+      "integrity": "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4"
+      }
+    },
+    "node_modules/multipasta": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.7.tgz",
+      "integrity": "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==",
+      "license": "MIT"
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.1.tgz",
+      "integrity": "sha512-c58R2+SPFcSIPXoU834QN/KPDDOSd8sXcSrqf6e83Me6Rrp1EYkxukkjXMVrKvKaADs1SOyNkWdfvLf6zY8qLQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/toml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-4.1.1.tgz",
+      "integrity": "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.8",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/docs/authenticators.md
+++ b/docs/authenticators.md
@@ -6,7 +6,7 @@ used by this plugin (gocql) only accepts a fixed allow-list of server-side
 authenticator class names, and refuses to connect to anything else with an error
 like:
 
-```
+```text
 Failed to create Cassandra connection
 cluster.CreateSession: gocql: unable to create session: unable to discover protocol version:
 unexpected authenticator "org.apache.cassandra.auth.LDAPAuthenticator"

--- a/docs/authenticators.md
+++ b/docs/authenticators.md
@@ -1,0 +1,85 @@
+# Custom Authenticators (LDAP, etc.)
+
+Some Cassandra clusters authenticate clients with a non-standard authenticator —
+for example `org.apache.cassandra.auth.LDAPAuthenticator`. By default the driver
+used by this plugin (gocql) only accepts a fixed allow-list of server-side
+authenticator class names, and refuses to connect to anything else with an error
+like:
+
+```
+Failed to create Cassandra connection
+cluster.CreateSession: gocql: unable to create session: unable to discover protocol version:
+unexpected authenticator "org.apache.cassandra.auth.LDAPAuthenticator"
+```
+
+This happens during protocol negotiation, *before* your credentials are even
+sent — so it is not a username/password problem.
+
+## The `Allowed authenticators` setting
+
+The **Allowed authenticators** connection setting lets you tell the driver which
+server-side authenticators it is allowed to authenticate against. Add your
+cluster's authenticator class name and the connection will succeed.
+
+* It is a **semicolon-separated** list of fully-qualified authenticator class names.
+* **Leaving it empty preserves the original behaviour** — the driver falls back
+  to its built-in default allow-list (see below). Existing data sources are
+  therefore unaffected.
+* The list **replaces** the default list rather than extending it. If your
+  cluster can negotiate more than one authenticator, include each one you want to
+  allow.
+
+
+## Configuring in the UI
+
+Open the data source settings and, under **Connection settings**, fill in
+**Allowed authenticators**, e.g.:
+
+```
+org.apache.cassandra.auth.PasswordAuthenticator;org.apache.cassandra.auth.LDAPAuthenticator
+```
+
+Then **Save & test**.
+
+## Configuring via provisioning
+
+Set the `allowedAuthenticators` key under `jsonData`:
+
+```yaml
+apiVersion: 1
+datasources:
+  - name: "Cassandra (LDAP)"
+    type: hadesarchitect-cassandra-datasource
+    access: proxy
+    url: "cassandra:9042"
+    jsonData:
+      keyspace: system
+      consistency: ONE
+      user: cassandra
+      allowedAuthenticators: "org.apache.cassandra.auth.PasswordAuthenticator;org.apache.cassandra.auth.LDAPAuthenticator"
+    secureJsonData:
+      password: cassandra
+```
+
+## Default allow-list
+
+When **Allowed authenticators** is left empty, the driver accepts the following
+authenticators (its built-in defaults):
+
+```
+org.apache.cassandra.auth.PasswordAuthenticator
+com.instaclustr.cassandra.auth.SharedSecretAuthenticator
+com.datastax.bdp.cassandra.auth.DseAuthenticator
+io.aiven.cassandra.auth.AivenAuthenticator
+com.ericsson.bss.cassandra.ecaudit.auth.AuditPasswordAuthenticator
+com.amazon.helenus.auth.HelenusAuthenticator
+com.ericsson.bss.cassandra.ecaudit.auth.AuditAuthenticator
+com.scylladb.auth.SaslauthdAuthenticator
+com.scylladb.auth.TransitionalAuthenticator
+com.instaclustr.cassandra.auth.InstaclustrPasswordAuthenticator
+```
+
+If your cluster uses one of these, you do not need to set anything. If it uses
+something else (such as `LDAPAuthenticator`), add it — and remember the list
+replaces the defaults, so include `PasswordAuthenticator` too if you still need
+it.

--- a/docs/authenticators.md
+++ b/docs/authenticators.md
@@ -29,13 +29,12 @@ cluster's authenticator class name and the connection will succeed.
   cluster can negotiate more than one authenticator, include each one you want to
   allow.
 
-
 ## Configuring in the UI
 
 Open the data source settings and, under **Connection settings**, fill in
 **Allowed authenticators**, e.g.:
 
-```
+```text
 org.apache.cassandra.auth.PasswordAuthenticator;org.apache.cassandra.auth.LDAPAuthenticator
 ```
 
@@ -66,7 +65,7 @@ datasources:
 When **Allowed authenticators** is left empty, the driver accepts the following
 authenticators (its built-in defaults):
 
-```
+```text
 org.apache.cassandra.auth.PasswordAuthenticator
 com.instaclustr.cassandra.auth.SharedSecretAuthenticator
 com.datastax.bdp.cassandra.auth.DseAuthenticator

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,7 @@
 | [Installation](https://github.com/HadesArchitect/GrafanaCassandraDatasource/blob/main/docs/installation.md) | GUI, CLI, and manual plugin install |
 | [Quick Demo](https://github.com/HadesArchitect/GrafanaCassandraDatasource/blob/main/docs/quick-demo.md) | Run the full stack locally with Docker Compose |
 | [Provisioning](https://github.com/HadesArchitect/GrafanaCassandraDatasource/blob/main/docs/provisioning.md) | Auto-configure the datasource via YAML (basic & TLS) |
+| [Custom Authenticators](https://github.com/HadesArchitect/GrafanaCassandraDatasource/blob/main/docs/authenticators.md) | Allow non-default authenticators such as LDAPAuthenticator |
 
 ## Querying
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,6 @@
 | [Installation](https://github.com/HadesArchitect/GrafanaCassandraDatasource/blob/main/docs/installation.md) | GUI, CLI, and manual plugin install |
 | [Quick Demo](https://github.com/HadesArchitect/GrafanaCassandraDatasource/blob/main/docs/quick-demo.md) | Run the full stack locally with Docker Compose |
 | [Provisioning](https://github.com/HadesArchitect/GrafanaCassandraDatasource/blob/main/docs/provisioning.md) | Auto-configure the datasource via YAML (basic & TLS) |
-| [Custom Authenticators](https://github.com/HadesArchitect/GrafanaCassandraDatasource/blob/main/docs/authenticators.md) | Allow non-default authenticators such as LDAPAuthenticator |
 
 ## Querying
 
@@ -24,6 +23,7 @@
 | ----- | --------------- |
 | [Partitions](https://github.com/HadesArchitect/GrafanaCassandraDatasource/blob/main/docs/partitions.md) | Fat-partition problem and time-bucketing strategy |
 | [Unix Epoch Time](https://github.com/HadesArchitect/GrafanaCassandraDatasource/blob/main/docs/unix-epoch.md) | Querying `bigint` timestamps stored as seconds or milliseconds |
+| [Custom Authenticators](https://github.com/HadesArchitect/GrafanaCassandraDatasource/blob/main/docs/authenticators.md) | Allow non-default authenticators such as LDAPAuthenticator |
 
 ## Connections
 

--- a/docs/provisioning.md
+++ b/docs/provisioning.md
@@ -121,6 +121,7 @@ datasources:
 ```
 
 3. Start the services:
+
 ```bash
 docker-compose up -d
 ```

--- a/docs/provisioning.md
+++ b/docs/provisioning.md
@@ -48,6 +48,10 @@ datasources:
       password: cassandra
 ```
 
+> Connecting to a cluster that uses a non-default authenticator (e.g.
+> `org.apache.cassandra.auth.LDAPAuthenticator`)? Set the `allowedAuthenticators`
+> key under `jsonData` — see [Custom Authenticators](authenticators.md).
+
 ### TLS Configuration with File Paths
 
 ```datasource/cassandra-tls-files.yaml

--- a/pkg/cassandra/session.go
+++ b/pkg/cassandra/session.go
@@ -12,13 +12,14 @@ import (
 
 // Settings is a set of Cassandra session settings.
 type Settings struct {
-	Hosts       []string
-	Keyspace    string
-	User        string
-	Password    string
-	Consistency string
-	Timeout     *int
-	TLSConfig   *tls.Config
+	Hosts                 []string
+	Keyspace              string
+	User                  string
+	Password              string
+	Consistency           string
+	Timeout               *int
+	TLSConfig             *tls.Config
+	AllowedAuthenticators []string
 }
 
 // Session is a convenience wrapper for the gocql.Session.
@@ -32,9 +33,14 @@ func New(cfg Settings) (*Session, error) {
 	cluster.DisableInitialHostLookup = true // required, AWS specific
 	cluster.Keyspace = cfg.Keyspace
 
+	// AllowedAuthenticators is left unset when empty so that gocql applies its
+	// built-in default allow-list, keeping backwards compatibility. When provided
+	// (e.g. to permit org.apache.cassandra.auth.LDAPAuthenticator) it overrides
+	// the default list.
 	cluster.Authenticator = gocql.PasswordAuthenticator{
-		Username: cfg.User,
-		Password: cfg.Password,
+		Username:              cfg.User,
+		Password:              cfg.Password,
+		AllowedAuthenticators: cfg.AllowedAuthenticators,
 	}
 
 	consistencyLevel, err := gocql.ParseConsistencyWrapper(cfg.Consistency)

--- a/pkg/main.go
+++ b/pkg/main.go
@@ -45,6 +45,11 @@ func newDataSource(ctx context.Context, settings backend.DataSourceInstanceSetti
 		}
 	}
 
+	allowedAuthenticators := parseAllowedAuthenticators(dss.AllowedAuthenticators)
+	if len(allowedAuthenticators) > 0 {
+		backend.Logger.Debug("Using custom authenticator", "authenticators", strings.Join(allowedAuthenticators, ";"))
+	}
+
 	sessionSettings := cassandra.Settings{
 		Hosts:                 strings.Split(settings.URL, ";"),
 		Keyspace:              dss.Keyspace,
@@ -53,7 +58,7 @@ func newDataSource(ctx context.Context, settings backend.DataSourceInstanceSetti
 		Consistency:           dss.Consistency,
 		Timeout:               dss.Timeout,
 		TLSConfig:             tlsConfig,
-		AllowedAuthenticators: parseAllowedAuthenticators(dss.AllowedAuthenticators),
+		AllowedAuthenticators: allowedAuthenticators,
 	}
 
 	session, err := cassandra.New(sessionSettings)

--- a/pkg/main.go
+++ b/pkg/main.go
@@ -46,13 +46,14 @@ func newDataSource(ctx context.Context, settings backend.DataSourceInstanceSetti
 	}
 
 	sessionSettings := cassandra.Settings{
-		Hosts:       strings.Split(settings.URL, ";"),
-		Keyspace:    dss.Keyspace,
-		User:        dss.User,
-		Password:    settings.DecryptedSecureJSONData["password"],
-		Consistency: dss.Consistency,
-		Timeout:     dss.Timeout,
-		TLSConfig:   tlsConfig,
+		Hosts:                 strings.Split(settings.URL, ";"),
+		Keyspace:              dss.Keyspace,
+		User:                  dss.User,
+		Password:              settings.DecryptedSecureJSONData["password"],
+		Consistency:           dss.Consistency,
+		Timeout:               dss.Timeout,
+		TLSConfig:             tlsConfig,
+		AllowedAuthenticators: parseAllowedAuthenticators(dss.AllowedAuthenticators),
 	}
 
 	session, err := cassandra.New(sessionSettings)

--- a/pkg/settings.go
+++ b/pkg/settings.go
@@ -6,22 +6,43 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 )
 
 // dataSourceSettings is a convenient presentation of a
 // backend.DataSourceInstanceSettings JSON data.
 type dataSourceSettings struct {
-	Keyspace         string `json:"keyspace"`
-	User             string `json:"user"`
-	Password         string `json:"password"`
-	Consistency      string `json:"consistency"`
-	CertPath         string `json:"certPath"`
-	RootPath         string `json:"rootPath"`
-	CaPath           string `json:"caPath"`
-	UseCertContent   bool   `json:"useCertContent"`
-	Timeout          *int   `json:"timeout"`
-	UseCustomTLS     bool   `json:"UseCustomTLS"`
-	AllowInsecureTLS bool   `json:"allowInsecureTLS"`
+	Keyspace              string `json:"keyspace"`
+	User                  string `json:"user"`
+	Password              string `json:"password"`
+	Consistency           string `json:"consistency"`
+	CertPath              string `json:"certPath"`
+	RootPath              string `json:"rootPath"`
+	CaPath                string `json:"caPath"`
+	UseCertContent        bool   `json:"useCertContent"`
+	Timeout               *int   `json:"timeout"`
+	UseCustomTLS          bool   `json:"UseCustomTLS"`
+	AllowInsecureTLS      bool   `json:"allowInsecureTLS"`
+	AllowedAuthenticators string `json:"allowedAuthenticators"`
+}
+
+// parseAllowedAuthenticators splits the semicolon-separated allowedAuthenticators
+// setting into a slice, trimming whitespace and dropping empty entries. It
+// returns nil when no authenticators are configured so that gocql falls back to
+// its built-in default list.
+func parseAllowedAuthenticators(raw string) []string {
+	parts := strings.Split(raw, ";")
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+
+	return result
 }
 
 // prepareTLSCfgFromPaths creates a tls.Config using certificate file paths.

--- a/pkg/settings_test.go
+++ b/pkg/settings_test.go
@@ -7,6 +7,49 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func Test_parseAllowedAuthenticators(t *testing.T) {
+	testCases := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{
+			name: "empty string returns nil (gocql default)",
+			raw:  "",
+			want: nil,
+		},
+		{
+			name: "whitespace only returns nil",
+			raw:  "   ;  ; ",
+			want: nil,
+		},
+		{
+			name: "single value",
+			raw:  "org.apache.cassandra.auth.LDAPAuthenticator",
+			want: []string{"org.apache.cassandra.auth.LDAPAuthenticator"},
+		},
+		{
+			name: "multiple values are trimmed",
+			raw:  " org.apache.cassandra.auth.PasswordAuthenticator ; org.apache.cassandra.auth.LDAPAuthenticator ",
+			want: []string{
+				"org.apache.cassandra.auth.PasswordAuthenticator",
+				"org.apache.cassandra.auth.LDAPAuthenticator",
+			},
+		},
+		{
+			name: "empty entries are dropped",
+			raw:  "a;;b;",
+			want: []string{"a", "b"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, parseAllowedAuthenticators(tc.raw))
+		})
+	}
+}
+
 func Test_prepareTLSCfgFromPaths(t *testing.T) {
 	testCases := []struct {
 		name            string

--- a/src/ConfigEditor.tsx
+++ b/src/ConfigEditor.tsx
@@ -207,11 +207,12 @@ export class ConfigEditor extends PureComponent<Props, State> {
                 invalid={options.url === ''}
                 onChange={this.onHostChange}
                 width={60}
+                required
               />
             </InlineField>
           </InlineFieldRow>
           <InlineFieldRow>
-            <InlineField label="Keyspace" labelWidth={25}>
+            <InlineField label="Keyspace" labelWidth={25} tooltip="Optional, defines default keyspace">
               <Input
                 name="keyspace"
                 value={options.jsonData.keyspace}
@@ -282,7 +283,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
             <InlineField
               label="Allowed authenticators"
               labelWidth={25}
-              tooltip="Semicolon-separated list of server-side authenticator class names the driver may authenticate against. Add your cluster's authenticator (e.g. org.apache.cassandra.auth.LDAPAuthenticator) here. Leave empty to use the gocql driver defaults."
+              tooltip='Leave empty unless gocql rejects your cluster with an "unexpected authenticator" error. If it does, add the authenticator class name(s) your cluster announces (e.g. org.apache.cassandra.auth.LDAPAuthenticator), semicolon-separated. Replaces (does not extend) the built-in defaults.'
             >
               <Input
                 name="allowedAuthenticators"

--- a/src/ConfigEditor.tsx
+++ b/src/ConfigEditor.tsx
@@ -85,6 +85,15 @@ export class ConfigEditor extends PureComponent<Props, State> {
     onOptionsChange({ ...options, jsonData });
   };
 
+  onAllowedAuthenticatorsChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const { onOptionsChange, options } = this.props;
+    const jsonData = {
+      ...options.jsonData,
+      allowedAuthenticators: event.target.value,
+    };
+    onOptionsChange({ ...options, jsonData });
+  };
+
   onUseCustomTLSChange = (event: React.FormEvent<HTMLInputElement>) => {
     const { onOptionsChange, options } = this.props;
     const jsonData = {
@@ -188,7 +197,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
           <InlineFieldRow>
             <InlineField
               label="Host"
-              labelWidth={20}
+              labelWidth={25}
               tooltip="Specify host and port like `192.168.12.134:9042`. You can specify multiple contact points using semicolon, f.e. `host1:9042;host2:9042;host3:9042`"
             >
               <Input
@@ -202,7 +211,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
             </InlineField>
           </InlineFieldRow>
           <InlineFieldRow>
-            <InlineField label="Keyspace" labelWidth={20}>
+            <InlineField label="Keyspace" labelWidth={25}>
               <Input
                 name="keyspace"
                 value={options.jsonData.keyspace}
@@ -213,7 +222,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
             </InlineField>
           </InlineFieldRow>
           <InlineFieldRow>
-            <InlineField label="Consistency" labelWidth={20}>
+            <InlineField label="Consistency" labelWidth={25}>
               <Select
                 placeholder="choose consistency"
                 options={consistencyOptions}
@@ -235,7 +244,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
             <InlineField
               label="Credentials"
               tooltip="We strongly recommend to create a custom Cassandra user for Grafana with strictly read-only permissions!"
-              labelWidth={20}
+              labelWidth={25}
             >
               <Input
                 name="user"
@@ -257,7 +266,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
             </InlineField>
           </InlineFieldRow>
           <InlineFieldRow>
-            <InlineField label="Timeout" labelWidth={20} tooltip="Timeout in seconds. Keep empty for the default value">
+            <InlineField label="Timeout" labelWidth={25} tooltip="Timeout in seconds. Keep empty for the default value">
               <Input
                 name="timeout"
                 placeholder=""
@@ -265,6 +274,21 @@ export class ConfigEditor extends PureComponent<Props, State> {
                 step={1}
                 value={options.jsonData.timeout}
                 onChange={this.onTimeoutChange}
+                width={60}
+              />
+            </InlineField>
+          </InlineFieldRow>
+          <InlineFieldRow>
+            <InlineField
+              label="Allowed authenticators"
+              labelWidth={25}
+              tooltip="Semicolon-separated list of server-side authenticator class names the driver may authenticate against. Add your cluster's authenticator (e.g. org.apache.cassandra.auth.LDAPAuthenticator) here. Leave empty to use the gocql driver defaults."
+            >
+              <Input
+                name="allowedAuthenticators"
+                value={options.jsonData.allowedAuthenticators ?? ''}
+                placeholder="org.apache.cassandra.auth.PasswordAuthenticator;org.apache.cassandra.auth.LDAPAuthenticator;etc"
+                onChange={this.onAllowedAuthenticatorsChange}
                 width={60}
               />
             </InlineField>

--- a/src/__tests__/ConfigEditor.test.tsx
+++ b/src/__tests__/ConfigEditor.test.tsx
@@ -37,6 +37,7 @@ describe('ConfigEditor', () => {
           useCustomTLS: false,
           timeout: 0,
           allowInsecureTLS: false,
+          allowedAuthenticators: '',
         }),
         secureJsonData: {},
         secureJsonFields: {},

--- a/src/models.ts
+++ b/src/models.ts
@@ -32,6 +32,7 @@ export interface CassandraDataSourceOptions extends DataSourceJsonData {
   useCustomTLS: boolean;
   timeout: number;
   allowInsecureTLS: boolean;
+  allowedAuthenticators: string;
 }
 
 type CassandraQueryType = 'query' | 'alert';

--- a/src/models.ts
+++ b/src/models.ts
@@ -32,7 +32,7 @@ export interface CassandraDataSourceOptions extends DataSourceJsonData {
   useCustomTLS: boolean;
   timeout: number;
   allowInsecureTLS: boolean;
-  allowedAuthenticators: string;
+  allowedAuthenticators?: string;
 }
 
 type CassandraQueryType = 'query' | 'alert';


### PR DESCRIPTION
Hi,

We recently tried using this plugin and after configuring everything, it failed querying the Cassandra cluster due to gocql driver failing to validate our authenticator against its default allow-list:
```
msg="Failed to create Cassandra connection" Message="cluster.CreateSession: gocql: unable to create session: unable to discover protocol version: unexpected authenticator \"org.apache.cassandra.auth.LDAPAuthenticator\""
```

This was also reported in this [issue](https://github.com/HadesArchitect/GrafanaCassandraDatasource/issues/156) a while back.

It seems that recent versions of qocql driver support an argument to override the default allow-list which this PR allows setting from the frontend. The frontend string is a semicolon separated string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring custom Cassandra authenticators in the data source settings.
  * Introduced an **Allowed authenticators** option that accepts a semicolon-separated list of authenticator class names.

* **UI Improvements**
  * Added an “Allowed authenticators” input to the connection settings screen.

* **Documentation**
  * Added a new “Custom Authenticators” documentation page and linked it from the Getting Started section.
  * Updated provisioning docs with guidance for non-default authenticators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->