### PR TITLE
feat(provisioning): add Cassandra datasource and dashboard provisioning configs

### DIFF
--- a/demo/dashboard.json
+++ b/demo/dashboard.json
@@ -354,7 +354,7 @@
           "queryType": "query",
           "rawQuery": true,
           "refId": "A",
-          "target": "SELECT sensor_id, temperature, registered_at, location FROM test.test WHERE location = '${loc}' AND registered_at > $__timeFrom and registered_at < $__timeTo",
+          "target": "SELECT sensor_id, temperature, registered_at, location FROM test.test WHERE location = '${loc}' AND registered_at > $__timeFrom and registered_at < $__timeTo ALLOW FILTERING",
           "type": "timeserie"
         }
       ],
@@ -680,7 +680,7 @@
         "name": "loc",
         "options": [],
         "query": {
-          "rawQuery": "select location from test.sensors_locations where bucket = 'default'"
+          "query": "select location from test.sensors_locations where bucket = 'default'"
         },
         "refresh": 1,
         "regex": "",

--- a/demo/dashboard.json
+++ b/demo/dashboard.json
@@ -354,7 +354,7 @@
           "queryType": "query",
           "rawQuery": true,
           "refId": "A",
-          "target": "SELECT sensor_id, temperature, registered_at, location FROM test.test WHERE sensor_id = ${loc} AND registered_at > $__timeFrom and registered_at < $__timeTo",
+          "target": "SELECT sensor_id, temperature, registered_at, location FROM test.test WHERE location = '${loc}' AND registered_at > $__timeFrom and registered_at < $__timeTo",
           "type": "timeserie"
         }
       ],

--- a/provisioning/dashboards/cassandra-demo.json
+++ b/provisioning/dashboards/cassandra-demo.json
@@ -311,7 +311,7 @@
           "queryType": "query",
           "rawQuery": true,
           "refId": "A",
-          "target": "SELECT sensor_id, temperature, registered_at, location FROM test.test WHERE location = '${loc}' AND registered_at > $__timeFrom and registered_at < $__timeTo",
+          "target": "SELECT sensor_id, temperature, registered_at, location FROM test.test WHERE location = '${loc}' AND registered_at > $__timeFrom and registered_at < $__timeTo ALLOW FILTERING",
           "type": "timeserie"
         }
       ],
@@ -627,7 +627,7 @@
         "name": "loc",
         "options": [],
         "query": {
-          "rawQuery": "select location from test.sensors_locations where bucket = 'default'"
+          "query": "select location from test.sensors_locations where bucket = 'default'"
         },
         "refresh": 1,
         "regex": "",

--- a/provisioning/dashboards/cassandra-demo.json
+++ b/provisioning/dashboards/cassandra-demo.json
@@ -1,47 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_APACHE_CASSANDRA",
-      "label": "Apache Cassandra",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "hadesarchitect-cassandra-datasource",
-      "pluginName": "Apache Cassandra"
-    }
-  ],
-  "__elements": {},
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "10.1.1"
-    },
-    {
-      "type": "panel",
-      "id": "graph",
-      "name": "Graph (old)",
-      "version": ""
-    },
-    {
-      "type": "datasource",
-      "id": "hadesarchitect-cassandra-datasource",
-      "name": "Apache Cassandra",
-      "version": "2.3.0"
-    },
-    {
-      "type": "panel",
-      "id": "table",
-      "name": "Table",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "timeseries",
-      "name": "Time series",
-      "version": ""
-    }
-  ],
   "annotations": {
     "list": [
       {
@@ -68,7 +25,7 @@
     {
       "datasource": {
         "type": "hadesarchitect-cassandra-datasource",
-        "uid": "${DS_APACHE_CASSANDRA}"
+        "uid": "cassandra-datasource"
       },
       "description": "This panel demonstrates the powerful Query Editor of Apache Cassandra Datasource for Grafana",
       "fieldConfig": {
@@ -152,7 +109,7 @@
           "columnValue": " ",
           "datasource": {
             "type": "hadesarchitect-cassandra-datasource",
-            "uid": "${DS_APACHE_CASSANDRA}"
+            "uid": "cassandra-datasource"
           },
           "datasourceId": 1,
           "queryType": "query",
@@ -173,7 +130,7 @@
       "dashes": false,
       "datasource": {
         "type": "hadesarchitect-cassandra-datasource",
-        "uid": "${DS_APACHE_CASSANDRA}"
+        "uid": "cassandra-datasource"
       },
       "description": "This panel is configured using Apache Cassandra Datasource and Query Configurator",
       "fill": 1,
@@ -218,7 +175,7 @@
           "columnValue": "temperature",
           "datasource": {
             "type": "hadesarchitect-cassandra-datasource",
-            "uid": "${DS_APACHE_CASSANDRA}"
+            "uid": "cassandra-datasource"
           },
           "datasourceId": 1,
           "instant": false,
@@ -264,7 +221,7 @@
     {
       "datasource": {
         "type": "hadesarchitect-cassandra-datasource",
-        "uid": "${DS_APACHE_CASSANDRA}"
+        "uid": "cassandra-datasource"
       },
       "description": "This panel demonstrates the powerful Query Editor of Apache Cassandra Datasource for Grafana",
       "fieldConfig": {
@@ -348,7 +305,7 @@
           "columnValue": " ",
           "datasource": {
             "type": "hadesarchitect-cassandra-datasource",
-            "uid": "${DS_APACHE_CASSANDRA}"
+            "uid": "cassandra-datasource"
           },
           "datasourceId": 1,
           "queryType": "query",
@@ -365,7 +322,7 @@
     {
       "datasource": {
         "type": "hadesarchitect-cassandra-datasource",
-        "uid": "${DS_APACHE_CASSANDRA}"
+        "uid": "cassandra-datasource"
       },
       "description": "This panel demonstrates the table mode of Apache Cassandra Datasource for Grafana",
       "fieldConfig": {
@@ -455,7 +412,7 @@
           "columnValue": " ",
           "datasource": {
             "type": "hadesarchitect-cassandra-datasource",
-            "uid": "${DS_APACHE_CASSANDRA}"
+            "uid": "cassandra-datasource"
           },
           "datasourceId": 1,
           "queryType": "query",
@@ -475,7 +432,6 @@
           "id": "organize",
           "options": {
             "excludeByName": {
-              "99051fe9-6a9c-46c2-b949-38ef78858dd1": false,
               "registered_at": true,
               "time": true
             },
@@ -486,11 +442,7 @@
               "temperature": 1
             },
             "renameByName": {
-              "99051fe9-6a9c-46c2-b949-38ef78858dd1": "Temperature",
-              "floor_number": "Floor №",
-              "id": "Sensor ID",
               "location": "Location",
-              "room_name": "Room Name",
               "sensor_id": "Sensor ID",
               "temperature": "Temperature"
             }
@@ -513,7 +465,7 @@
     {
       "datasource": {
         "type": "hadesarchitect-cassandra-datasource",
-        "uid": "${DS_APACHE_CASSANDRA}"
+        "uid": "cassandra-datasource"
       },
       "description": "This panel demonstrates the table mode of Apache Cassandra Datasource for Grafana",
       "fieldConfig": {
@@ -602,7 +554,7 @@
           "columnValue": "temperature",
           "datasource": {
             "type": "hadesarchitect-cassandra-datasource",
-            "uid": "${DS_APACHE_CASSANDRA}"
+            "uid": "cassandra-datasource"
           },
           "datasourceId": 1,
           "hide": false,
@@ -624,22 +576,17 @@
           "id": "organize",
           "options": {
             "excludeByName": {
-              "99051fe9-6a9c-46c2-b949-38ef78858dd1": false,
               "registered_at": true,
               "time": true
             },
             "indexByName": {
-              "floor_number": 2,
-              "registered_at": 4,
-              "room_name": 1,
+              "location": 2,
+              "registered_at": 3,
               "sensor_id": 0,
-              "temperature": 3
+              "temperature": 1
             },
             "renameByName": {
-              "99051fe9-6a9c-46c2-b949-38ef78858dd1": "Temperature",
-              "floor_number": "Floor №",
-              "id": "Sensor ID",
-              "room_name": "Room Name",
+              "location": "Location",
               "sensor_id": "Sensor ID",
               "temperature": "Temperature"
             }
@@ -670,9 +617,9 @@
         "current": {},
         "datasource": {
           "type": "hadesarchitect-cassandra-datasource",
-          "uid": "${DS_APACHE_CASSANDRA}"
+          "uid": "cassandra-datasource"
         },
-        "definition": "select location from test.sensors_locations where bucket = 'default'",
+        "definition": "select sensor_id, location from test.sensors_locations where bucket = 'default'",
         "hide": 0,
         "includeAll": false,
         "label": "",
@@ -680,7 +627,7 @@
         "name": "loc",
         "options": [],
         "query": {
-          "rawQuery": "select location from test.sensors_locations where bucket = 'default'"
+          "rawQuery": "select sensor_id, location from test.sensors_locations where bucket = 'default'"
         },
         "refresh": 1,
         "regex": "",
@@ -697,7 +644,7 @@
   "timepicker": {},
   "timezone": "",
   "title": "Cassandra Datasource Demo",
-  "uid": "g-XtNls7z",
-  "version": 21,
+  "uid": "cassandra-datasource-demo",
+  "version": 1,
   "weekStart": ""
 }

--- a/provisioning/dashboards/cassandra-demo.json
+++ b/provisioning/dashboards/cassandra-demo.json
@@ -311,7 +311,7 @@
           "queryType": "query",
           "rawQuery": true,
           "refId": "A",
-          "target": "SELECT sensor_id, temperature, registered_at, location FROM test.test WHERE sensor_id = ${loc} AND registered_at > $__timeFrom and registered_at < $__timeTo",
+          "target": "SELECT sensor_id, temperature, registered_at, location FROM test.test WHERE location = '${loc}' AND registered_at > $__timeFrom and registered_at < $__timeTo",
           "type": "timeserie"
         }
       ],
@@ -619,7 +619,7 @@
           "type": "hadesarchitect-cassandra-datasource",
           "uid": "cassandra-datasource"
         },
-        "definition": "select sensor_id, location from test.sensors_locations where bucket = 'default'",
+        "definition": "select location from test.sensors_locations where bucket = 'default'",
         "hide": 0,
         "includeAll": false,
         "label": "",
@@ -627,7 +627,7 @@
         "name": "loc",
         "options": [],
         "query": {
-          "rawQuery": "select sensor_id, location from test.sensors_locations where bucket = 'default'"
+          "rawQuery": "select location from test.sensors_locations where bucket = 'default'"
         },
         "refresh": 1,
         "regex": "",

--- a/provisioning/dashboards/dashboards.yaml
+++ b/provisioning/dashboards/dashboards.yaml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: Apache Cassandra Dashboards
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /etc/grafana/provisioning/dashboards
+      foldersFromFilesStructure: false

--- a/provisioning/datasources/cassandra.yaml
+++ b/provisioning/datasources/cassandra.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+datasources:
+  - name: Apache Cassandra
+    uid: cassandra-datasource
+    type: hadesarchitect-cassandra-datasource
+    access: proxy
+    url: cassandra:9042
+    editable: true
+    jsonData:
+      keyspace: test
+      consistency: ONE

--- a/src/VariableQueryEditor.tsx
+++ b/src/VariableQueryEditor.tsx
@@ -30,7 +30,7 @@ export const VariableQueryEditor = ({ onChange, query }: VariableQueryProps) => 
           onBlur={saveQuery}
           onChange={handleChange}
           value={state.query}
-          placeholder={'SELECT sensor_id, location FROM sensors.sensors_locations'}
+          placeholder={'SELECT location FROM sensors.sensors_locations'}
         />
         <br />
         <LinkButton href="https://github.com/HadesArchitect/GrafanaCassandraDatasource/blob/main/docs/variables.md" target="_blank" rel="noopener noreferrer" variant="secondary" size="sm" icon="external-link-alt">Learn more about variables</LinkButton>


### PR DESCRIPTION
Add Grafana provisioning configuration to automatically load the Cassandra datasource and demo dashboard on startup. This enables a containerized setup where Grafana can be fully configured through configuration-as-code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Grafana provisioning for an Apache Cassandra datasource.
  * Added a new demo dashboard with multiple panels showcasing queries, tables, and variable-driven filtering.
  * Added dashboard auto-loading settings so the demo appears in Grafana automatically.
* **Bug Fixes**
  * Updated a dashboard variable to return cleaner location options filtered to the default bucket.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->